### PR TITLE
Add Frontera integration via HCF

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ It's possible to use [Crawlera](https://scrapinghub.com/crawlera) to avoid bans 
 
 **Note**: Crawlera won't be used for your requests to AutoExtract API.
 
+#### Frontera
+
+[Frontera](https://github.com/scrapinghub/hcf-backend) integration is enabled by default using [HCF](https://doc.scrapinghub.com/api/frontier.html) [backend](https://github.com/scrapinghub/hcf-backend) to provide URL deduplication, a possibility to scale your crawler and some other interesting features out-of-the-box. It doesn't require additional settings: the default configuration enables producer/consumer behaviours within the same spider with fairly good defaults (using a single frontier slot).
+
+However you could always tune it according to your needs. If that's the case, it might be useful to get familiar with [shub-workflow](https://github.com/scrapinghub/shub-workflow/wiki/Basic-Tutorial) describing the topic and related settings in more detail.
+
+Shortly, you could scale a crawler by running multiple producers and consumers in parallel. An amount of slots in a single frontier defines how many consumer jobs you may have (note that each consumer reads only from a single slot). On the other hand, each producer writes data to all slots, so there's no limit on the amount of producer jobs.
+
+HCF backend logic can be modified by providing an additional spider argument ``frontera_settings_json`` with a settings dictionary in JSON format. For example, to launch your spider in producer-only mode, you should provide ``frontera_settings_json={"HCF_CONSUMER_FRONTIER":null}``(similarly, reset a setting ``HCF_PRODUCER_FRONTIER`` for consumer-only mode). Additional settings for the backend can be found [here](https://github.com/scrapinghub/hcf-backend/blob/0.4.3/hcf_backend/backend.py#L45) and get overwritten in the same way.
+
+URL deduplication provided by Frontera works in the following way: a frontera slot stores information about links even after consuming/deleting the links from the slot queue, so when you'll try to add the same link to the slot, it will be ignored. Sometimes the behaviour is not what's needed (like, when you want to recrawl with different parameters). The simplest solution in this case would be to drop a slot (or a whole frontier), using ``hcfpal.py`` script and recrawl from scratch. To delete a slot, launch the script from Dash UI providing a frontier name (default is ``autoextract``) and the slot prefix (default is ``articles``) or the full slot name via script arguments, like ``delete autoextract articles0``. The [hcfpal.py](https://github.com/scrapinghub/hcf-backend/blob/0.4.3/hcf_backend/utils/hcfpal.py) can be also used from your local machine after installing ``hcf-backend`` package, check its built-in command-line helper.
+
+**Note** Frontera integration can be disabled via **FRONTERA_DISABLED** setting.
+
 #### Other options
 
 * **DEPTH_LIMIT** (default 2): the maximum depth that will be allowed to crawl for a site.

--- a/autoextract_spiders/middlewares.py
+++ b/autoextract_spiders/middlewares.py
@@ -1,0 +1,35 @@
+from scrapy.settings import default_settings
+from scrapy_frontera.middlewares import (
+    SchedulerSpiderMiddleware as _SSpiderMiddleware,
+    SchedulerDownloaderMiddleware as _SDownloaderMiddleware,
+)
+
+
+def reset_scheduler_on_disabled_frontera(settings):
+    if settings.getbool('FRONTERA_DISABLED'):
+        settings['SCHEDULER'] = default_settings.SCHEDULER
+
+
+class FronteraDisabledMixin:
+    @property
+    def is_frontera_enabled(self):
+        return not self.crawler.settings.getbool('FRONTERA_DISABLED')
+
+
+class SchedulerSpiderMiddleware(_SSpiderMiddleware, FronteraDisabledMixin):
+    def process_spider_output(self, response, result, spider):
+        if self.is_frontera_enabled:
+            return self.scheduler.process_spider_output(response, result, spider)
+        yield from result
+
+    def process_start_requests(self, start_requests, spider):
+        redirect_setting = 'FRONTERA_SCHEDULER_START_REQUESTS_TO_FRONTIER'
+        redirect_requests = self.crawler.settings.getbool(redirect_setting)
+        if self.is_frontera_enabled and redirect_requests:
+            return []
+        return start_requests
+
+class SchedulerDownloaderMiddleware(_SDownloaderMiddleware, FronteraDisabledMixin):
+    def process_exception(self, request, exception, spider):
+        if self.is_frontera_enabled:
+            return self.scheduler.process_exception(request, exception, spider)

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -35,13 +35,19 @@ RETRY_HTTP_CODES = [429]
 # More spam from Link Filter Middleware
 # LINK_FILTER_MIDDLEWARE_DEBUG = True
 
+# Frontera settings
+SCHEDULER = 'scrapy_frontera.scheduler.FronteraScheduler'
+BACKEND = 'hcf_backend.HCFBackend'
+
 SPIDER_MIDDLEWARES = {
     'scrapy_link_filter.middleware.LinkFilterMiddleware': 950,
+    'scrapy_frontera.middlewares.SchedulerSpiderMiddleware': 0,
 }
 
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
+    'scrapy_frontera.middlewares.SchedulerDownloaderMiddleware': 0,
     'scrapy_crawlera.CrawleraMiddleware': 300,
     'scrapy_count_filter.middleware.GlobalCountFilterMiddleware': 541,
     'scrapy_count_filter.middleware.HostsCountFilterMiddleware': 542,

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -41,13 +41,13 @@ BACKEND = 'hcf_backend.HCFBackend'
 
 SPIDER_MIDDLEWARES = {
     'scrapy_link_filter.middleware.LinkFilterMiddleware': 950,
-    'scrapy_frontera.middlewares.SchedulerSpiderMiddleware': 0,
+    'autoextract_spiders.middlewares.SchedulerSpiderMiddleware': 0,
 }
 
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
-    'scrapy_frontera.middlewares.SchedulerDownloaderMiddleware': 0,
+    'autoextract_spiders.middlewares.SchedulerDownloaderMiddleware': 0,
     'scrapy_crawlera.CrawleraMiddleware': 300,
     'scrapy_count_filter.middleware.GlobalCountFilterMiddleware': 541,
     'scrapy_count_filter.middleware.HostsCountFilterMiddleware': 542,

--- a/autoextract_spiders/spiders/autoextract_article.py
+++ b/autoextract_spiders/spiders/autoextract_article.py
@@ -27,6 +27,8 @@ class ArticleAutoExtract(CrawlerSpider):
         spider = super().from_crawler(crawler, *args, **kwargs)
         spider.main_callback = spider.parse_source
         spider.main_errback = spider.errback_source
+        # A switch to enable revisiting article pages.
+        spider.dont_filter = spider.get_arg('dont-filter', False)
         return spider
 
     @crawlera_session.follow_session
@@ -53,7 +55,7 @@ class ArticleAutoExtract(CrawlerSpider):
                 meta=meta,
                 callback=self.parse_feed,
                 errback=self.errback_feed,
-                dont_filter=True)
+                dont_filter=True)  # parse the feed everytime
 
         # Cycle and follow all the rest of the links
         yield from self._requests_to_follow(response)
@@ -129,7 +131,7 @@ class ArticleAutoExtract(CrawlerSpider):
                           meta={'source_url': source_url, 'feed_url': feed_url},
                           callback=self.parse_page,
                           errback=self.errback_page,
-                          dont_filter=True)
+                          dont_filter=self.dont_filter)
 
     def errback_feed(self, failure):
         """ Feed XML request error """

--- a/autoextract_spiders/spiders/autoextract_article.py
+++ b/autoextract_spiders/spiders/autoextract_article.py
@@ -2,6 +2,7 @@ import feedparser
 from w3lib.html import strip_html5_whitespace
 from scrapy.http import Request, HtmlResponse, XmlResponse
 
+from ..middlewares import reset_scheduler_on_disabled_frontera
 from ..sessions import crawlera_session
 from .util import is_valid_url
 from .crawler_spider import CrawlerSpider
@@ -21,6 +22,11 @@ class ArticleAutoExtract(CrawlerSpider):
         'HCF_CONSUMER_SLOT': 'articles0',
         'HCF_CONSUMER_MAX_REQUESTS': 100,
     }
+
+    @classmethod
+    def update_settings(cls, settings):
+        super().update_settings(settings)
+        reset_scheduler_on_disabled_frontera(settings)
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -1,11 +1,9 @@
-import hashlib
 import logging
 
 from scrapy import signals
 from scrapy.spiders import Spider
 from scrapy.http import Request
 from scrapy.exceptions import IgnoreRequest, DropItem
-from scrapy.utils.request import request_fingerprint
 
 from .util import load_sources, is_valid_url, is_blacklisted_url
 from .util import utc_iso_date, maybe_is_article, maybe_is_product
@@ -37,11 +35,6 @@ class AutoExtractRequest(Request):
             self.meta['autoextract'] = {'enabled': True}
             if page_type:
                 self.meta['autoextract']['pageType'] = page_type
-
-        # Request fingerprint for Frontera requests
-        if meta.get('cf_store') and 'source_url' in meta:
-            fp = request_fingerprint(self).encode()
-            meta['frontier_fingerprint'] = hashlib.sha1(fp).hexdigest()
 
     def __str__(self):
         return f'<AutoExtract {self.url}>'

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -253,7 +253,7 @@ class CrawlerSpider(AutoExtractSpider):
         valid_links = []
         for lnk in links:
             host = urlsplit(lnk.url).netloc.lower()
-            if host in self.allowed_domains:
+            if not hasattr(self, 'allowed_domains') or host in self.allowed_domains:
                 valid_links.append(lnk)
         return valid_links
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ scrapy_crawlera~=1.6.0
 crawlera-session==1.0.1
 # frontera support
 scrapy-frontera~=0.2.0
-hcf-backend~=0.2.5
+hcf-backend~=0.4.3
 
 git+https://github.com/croqaz/scrapy-link-filter
 git+https://github.com/croqaz/scrapy-count-filter

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,12 @@ ujson>=1.34
 PyYAML<=3.13,>=3.10
 
 scrapy-autoextract>=0.1
+# crawlera support
 scrapy_crawlera~=1.6.0
 crawlera-session==1.0.1
+# frontera support
+scrapy-frontera~=0.2.0
+hcf-backend~=0.2.5
 
 git+https://github.com/croqaz/scrapy-link-filter
 git+https://github.com/croqaz/scrapy-count-filter

--- a/scripts/hcfpal.py
+++ b/scripts/hcfpal.py
@@ -1,0 +1,5 @@
+from hcf_backend.utils.hcfpal import HCFPalScript
+
+if __name__ == '__main__':
+    script = HCFPalScript()
+    script.run()

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -1,0 +1,5 @@
+from hcf_backend.utils.hcfmanager import HCFSpiderManager
+
+if __name__ == '__main__':
+    manager = HCFSpiderManager()
+    manager.run()

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(
     author='Scrapinghub Inc',
     description='Scrapinghub AutoExtract spiders',
     packages=find_packages(exclude=['tests']),
-    scripts=['scripts/manager.py'],
+    scripts=['scripts/hcfpal.py', 'scripts/manager.py'],
     entry_points={'scrapy': ['settings = autoextract_spiders.settings']},
 )

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ setup(
     author='Scrapinghub Inc',
     description='Scrapinghub AutoExtract spiders',
     packages=find_packages(exclude=['tests']),
+    scripts=['scripts/manager.py'],
     entry_points={'scrapy': ['settings = autoextract_spiders.settings']},
 )


### PR DESCRIPTION
The PR brings basic Frontera/HCF support to the articles spider, enabled by default (I still wonder if it's something that must be optional, it's not straightforward to disable it via some settings - at least I haven't found any, but in the worst case we could have a separate spider class). In addition to setting `AUTOEXTRACT_USER`, it needs `HCF_AUTH = <Scrapinghub API key>` setting to set HCF backend for Frontera, but that's it. I'll leave some comments to explain the decisions and trigger further discussion if needed.

The approach also allows to run a crawler in production/consumer mode (or in both at the same time) by (un)setting `HCF_PRODUCER_FRONTIER/HCF_CONSUMER_FRONTIER`. What we probably could do is try to simplify the interface by adding `--producer/--consumer` spider args, and ensure that it works fine with existing `--discovery-only` spider arg.

Ready for initial review. @kmike @croqaz 