### PR TITLE
Update Scrapy stack version

### DIFF
--- a/scrapinghub.yml
+++ b/scrapinghub.yml
@@ -1,5 +1,4 @@
 version: GIT
-image: true
-stack: scrapy:1.7-py3
+stack: scrapy:1.7-py38
 requirements:
   file: requirements.txt


### PR DESCRIPTION
- `image` can't be used along with `stack`
- let's use the latest stack available with py3.8