### PR TITLE
Add optional Crawlera support

### DIFF
--- a/autoextract_spiders/sessions.py
+++ b/autoextract_spiders/sessions.py
@@ -27,3 +27,6 @@ class RequestSession(_Session):
             yield from (orig_wrapper if is_crawlera_enabled else wrapped)(spider, response)
         _wrapper.__name__ = wrapped.__name__
         return _wrapper
+
+
+crawlera_session = RequestSession(x_crawlera_profile='desktop')

--- a/autoextract_spiders/sessions.py
+++ b/autoextract_spiders/sessions.py
@@ -1,0 +1,29 @@
+
+from crawlera_session import RequestSession as _Session
+
+
+def update_redirect_middleware(settings):
+    if settings.getbool('CRAWLERA_ENABLED'):
+        redirect_mware = 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware'
+        pos = settings.get('DOWNLOADER_MIDDLEWARES_BASE').pop(redirect_mware)
+        DW_MIDDLEWARES = settings.get('DOWNLOADER_MIDDLEWARES')
+        DW_MIDDLEWARES['crawlera_session.CrawleraSessionRedirectMiddleware'] = pos
+
+
+class RequestSession(_Session):
+
+    def init_start_requests(self, wrapped):
+        orig_wrapper = super().init_start_requests(wrapped)
+        def _wrapper(spider):
+            is_crawlera_enabled = spider.settings.getbool('CRAWLERA_ENABLED')
+            yield from (orig_wrapper if is_crawlera_enabled else wrapped)(spider)
+        _wrapper.__name__ = wrapped.__name__
+        return _wrapper
+
+    def follow_session(self, wrapped):
+        orig_wrapper = super().follow_session(wrapped)
+        def _wrapper(spider, response):
+            is_crawlera_enabled = spider.settings.getbool('CRAWLERA_ENABLED')
+            yield from (orig_wrapper if is_crawlera_enabled else wrapped)(spider, response)
+        _wrapper.__name__ = wrapped.__name__
+        return _wrapper

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -42,9 +42,13 @@ SPIDER_MIDDLEWARES = {
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
+    'scrapy_crawlera.CrawleraMiddleware': 300,
     'scrapy_count_filter.middleware.GlobalCountFilterMiddleware': 541,
     'scrapy_count_filter.middleware.HostsCountFilterMiddleware': 542,
     'scrapy_autoextract.middlewares.AutoExtractMiddleware': 543,
 }
 
 AUTOEXTRACT_USER = '[API key]'
+
+CRAWLERA_ENABLED = False
+CRAWLERA_APIKEY = '[API key]'

--- a/autoextract_spiders/spiders/autoextract_article.py
+++ b/autoextract_spiders/spiders/autoextract_article.py
@@ -3,7 +3,7 @@ from w3lib.html import strip_html5_whitespace
 from scrapy.http import Request, HtmlResponse, XmlResponse
 
 from .util import is_valid_url
-from .crawler_spider import CrawlerSpider
+from .crawler_spider import CrawlerSpider, CRAWLERA_SESSION
 
 
 class ArticleAutoExtract(CrawlerSpider):
@@ -17,6 +17,7 @@ class ArticleAutoExtract(CrawlerSpider):
         spider.main_errback = spider.errback_source
         return spider
 
+    @CRAWLERA_SESSION.follow_session
     def parse_source(self, response: HtmlResponse):
         """
         Parse a seed URL.
@@ -71,6 +72,7 @@ class ArticleAutoExtract(CrawlerSpider):
 
         return feed_urls
 
+    @CRAWLERA_SESSION.follow_session
     def parse_feed(self, response: XmlResponse):
         """
         Parse a feed XML.

--- a/autoextract_spiders/spiders/autoextract_article.py
+++ b/autoextract_spiders/spiders/autoextract_article.py
@@ -2,8 +2,9 @@ import feedparser
 from w3lib.html import strip_html5_whitespace
 from scrapy.http import Request, HtmlResponse, XmlResponse
 
+from ..sessions import crawlera_session
 from .util import is_valid_url
-from .crawler_spider import CrawlerSpider, CRAWLERA_SESSION
+from .crawler_spider import CrawlerSpider
 
 
 class ArticleAutoExtract(CrawlerSpider):
@@ -17,7 +18,7 @@ class ArticleAutoExtract(CrawlerSpider):
         spider.main_errback = spider.errback_source
         return spider
 
-    @CRAWLERA_SESSION.follow_session
+    @crawlera_session.follow_session
     def parse_source(self, response: HtmlResponse):
         """
         Parse a seed URL.
@@ -72,7 +73,7 @@ class ArticleAutoExtract(CrawlerSpider):
 
         return feed_urls
 
-    @CRAWLERA_SESSION.follow_session
+    @crawlera_session.follow_session
     def parse_feed(self, response: XmlResponse):
         """
         Parse a feed XML.

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -16,7 +16,11 @@ SUPPORTED_TYPES = ('article', 'product')
 class AutoExtractRequest(Request):
 
     def __init__(self, url, **kwargs):
-        meta = kwargs.pop('meta', {})
+        meta = kwargs.pop('meta', None) or {}
+        meta.update(  # disable crawlera for all AE requests
+            dont_proxy=True,
+            no_crawlera_session=True,
+        )
         page_type = kwargs.pop('page_type', None)
         feed_url = kwargs.pop('feed_url', None)
         if feed_url:

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -8,7 +8,7 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.exceptions import IgnoreRequest, DropItem
 from scrapy.utils.misc import arg_to_iter
 
-from ..sessions import RequestSession, update_redirect_middleware
+from ..sessions import crawlera_session, update_redirect_middleware
 from .rule import Rule
 from .autoextract_spider import AutoExtractSpider
 from .util import is_valid_url, utc_iso_date, is_autoextract_request
@@ -18,8 +18,6 @@ META_TO_KEEP = ('source_url',)
 DEFAULT_ALLOWED_DOMAINS = ['xod.scrapinghub.com', 'autoextract.scrapinghub.com']
 
 DEFAULT_COUNT_LIMITS = {'page_count': 1000, 'item_count': 100}
-
-CRAWLERA_SESSION = RequestSession(x_crawlera_profile='desktop')
 
 
 class CrawlerSpider(AutoExtractSpider):
@@ -171,7 +169,7 @@ class CrawlerSpider(AutoExtractSpider):
 
         return self
 
-    @CRAWLERA_SESSION.init_start_requests
+    @crawlera_session.init_start_requests
     def start_requests(self):
         """
         The main function.
@@ -233,7 +231,7 @@ class CrawlerSpider(AutoExtractSpider):
         # so there are no links and nothing to follow
         if response.body:
             for request in self._requests_to_follow(response):
-                yield CRAWLERA_SESSION.init_request(request)
+                yield crawlera_session.init_request(request)
         elif is_autoextract_request(response):
             # Make another request to fetch the full page HTML
             # Risk of being banned
@@ -243,7 +241,7 @@ class CrawlerSpider(AutoExtractSpider):
                           callback=self.main_callback,
                           errback=self.main_errback,
                           dont_filter=True)
-            yield CRAWLERA_SESSION.init_request(request)
+            yield crawlera_session.init_request(request)
 
     def _rule_process_links(self, links):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ ujson>=1.34
 PyYAML<=3.13,>=3.10
 
 scrapy-autoextract>=0.1
+scrapy_crawlera~=1.6.0
+crawlera-session==1.0.0
 
 git+https://github.com/croqaz/scrapy-link-filter
 git+https://github.com/croqaz/scrapy-count-filter

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ PyYAML<=3.13,>=3.10
 
 scrapy-autoextract>=0.1
 scrapy_crawlera~=1.6.0
-crawlera-session==1.0.0
+crawlera-session==1.0.1
 
 git+https://github.com/croqaz/scrapy-link-filter
 git+https://github.com/croqaz/scrapy-count-filter


### PR DESCRIPTION
Supersedes #4 (not I nor Rafael has write access to the repository, so we have to use forks, and while Rafael is on vacation, I need to finish his work on the integration).

As discussed, Crawlera isn't used for AutoExtract requests itself, but for everything else. I also added sessions support to maintain same session during crawling. Looking forward to get any feedback on the changes.