### PR TITLE
Add optional fake-useragent support

### DIFF
--- a/autoextract_spiders/middlewares.py
+++ b/autoextract_spiders/middlewares.py
@@ -1,5 +1,4 @@
 from fake_useragent import UserAgent
-from scrapy import signals
 from scrapy.downloadermiddlewares.useragent import UserAgentMiddleware
 
 
@@ -11,7 +10,6 @@ class RandomUserAgentMiddleware(UserAgentMiddleware):
         if crawler.settings.get('FAKEUSERAGENT_ENABLED'):
             random_type = crawler.settings.get('FAKEUSERAGENT_TYPE', 'random')
         o = cls(user_agent, random_type=random_type)
-        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
         return o
 
     def __init__(self, user_agent='Scrapy', random_type=None):

--- a/autoextract_spiders/middlewares.py
+++ b/autoextract_spiders/middlewares.py
@@ -1,0 +1,27 @@
+from fake_useragent import UserAgent
+from scrapy import signals
+from scrapy.downloadermiddlewares.useragent import UserAgentMiddleware
+
+
+class RandomUserAgentMiddleware(UserAgentMiddleware):
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        user_agent, random_type = crawler.settings['USER_AGENT'], None
+        if crawler.settings.get('FAKEUSERAGENT_ENABLED'):
+            random_type = crawler.settings.get('FAKEUSERAGENT_TYPE', 'random')
+        o = cls(user_agent, random_type=random_type)
+        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
+        return o
+
+    def __init__(self, user_agent='Scrapy', random_type=None):
+        self.default_user_agent = user_agent
+        self.random_type = random_type
+        if self.random_type:
+            self.user_agent_helper = UserAgent(fallback=user_agent)
+
+    @property
+    def user_agent(self):
+        if self.random_type:
+            return getattr(self.user_agent_helper, self.random_type)
+        return self.default_user_agent

--- a/autoextract_spiders/middlewares.py
+++ b/autoextract_spiders/middlewares.py
@@ -7,7 +7,7 @@ class RandomUserAgentMiddleware(UserAgentMiddleware):
     @classmethod
     def from_crawler(cls, crawler):
         user_agent, random_type = crawler.settings['USER_AGENT'], None
-        if crawler.settings.get('FAKEUSERAGENT_ENABLED'):
+        if crawler.settings.getbool('FAKEUSERAGENT_ENABLED'):
             random_type = crawler.settings.get('FAKEUSERAGENT_TYPE', 'random')
         o = cls(user_agent, random_type=random_type)
         return o

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -44,10 +44,10 @@ SPIDER_MIDDLEWARES = {
 DOWNLOADER_MIDDLEWARES = {
     'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware': None,
     'scrapy_crawlera.CrawleraMiddleware': 300,
+    'autoextract_spiders.middlewares.RandomUserAgentMiddleware': 500,
     'scrapy_count_filter.middleware.GlobalCountFilterMiddleware': 541,
     'scrapy_count_filter.middleware.HostsCountFilterMiddleware': 542,
     'scrapy_autoextract.middlewares.AutoExtractMiddleware': 543,
-    'autoextract_spiders.middlewares.RandomUserAgentMiddleware': 998,
 }
 
 AUTOEXTRACT_USER = '[API key]'

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -47,7 +47,7 @@ DOWNLOADER_MIDDLEWARES = {
     'scrapy_count_filter.middleware.GlobalCountFilterMiddleware': 541,
     'scrapy_count_filter.middleware.HostsCountFilterMiddleware': 542,
     'scrapy_autoextract.middlewares.AutoExtractMiddleware': 543,
-    'scrapy_fake_useragent.middleware.RandomUserAgentMiddleware': 998,
+    'autoextract_spiders.middlewares.RandomUserAgentMiddleware': 998,
 }
 
 AUTOEXTRACT_USER = '[API key]'

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -42,10 +42,12 @@ SPIDER_MIDDLEWARES = {
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
+    'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware': None,
     'scrapy_crawlera.CrawleraMiddleware': 300,
     'scrapy_count_filter.middleware.GlobalCountFilterMiddleware': 541,
     'scrapy_count_filter.middleware.HostsCountFilterMiddleware': 542,
     'scrapy_autoextract.middlewares.AutoExtractMiddleware': 543,
+    'scrapy_fake_useragent.middleware.RandomUserAgentMiddleware': 998,
 }
 
 AUTOEXTRACT_USER = '[API key]'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ feedparser>=5.2
 ujson>=1.34
 PyYAML<=3.13,>=3.10
 
+scrapy-fake-useragent~=1.1.0
 scrapy-autoextract>=0.1
 scrapy_crawlera~=1.6.0
 crawlera-session==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ feedparser>=5.2
 ujson>=1.34
 PyYAML<=3.13,>=3.10
 
-scrapy-fake-useragent~=1.1.0
+fake-useragent~=0.1.11
 scrapy-autoextract>=0.1
 scrapy_crawlera~=1.6.0
 crawlera-session==1.0.1


### PR DESCRIPTION
Supersedes #5  (not I nor Rafael has write access to the repository, so we have to use forks, and while Rafael is on vacation, I need to finish his work on the feature).

Like we discussed recently with @kmike, the middleware should be disabled by default (and there should be an option to enable it via settings). The `scrapy-fake-useragent` doesn't provide a simple way to do that, so I went to a custom version based on the default Scrapy mware. Also as `scrapy-fake-useragent` doesn't provide any additional benefits, it seems better to just replace it.