### PR TITLE
Updated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ feedparser>=5.2
 ujson>=1.34
 PyYAML<=3.13,>=3.10
 
-scrapy-autoextract>=0.1
+scrapy-autoextract>=0.3
 # crawlera support
 scrapy_crawlera~=1.6.0
 crawlera-session==1.0.1
@@ -12,5 +12,5 @@ crawlera-session==1.0.1
 scrapy-frontera~=0.2.0
 hcf-backend~=0.4.3
 
-git+https://github.com/croqaz/scrapy-link-filter
-git+https://github.com/croqaz/scrapy-count-filter
+scrapy-link-filter~=0.2
+scrapy-count-filter~=0.2


### PR DESCRIPTION
Pretty easy. Tested locally and it works.

scrapy-autoextract was updated.
scrapy-link-filter and scrapy-count-filter are now on Pypi.