### PR TITLE
Deduplication to avoid infinite loops. Better priority queue for multiple domains.

### DIFF
--- a/autoextract_spiders/dupe_filter.py
+++ b/autoextract_spiders/dupe_filter.py
@@ -1,0 +1,18 @@
+from scrapy.dupefilters import RFPDupeFilter
+from scrapy.utils.request import request_fingerprint
+
+
+class DupeFilter(RFPDupeFilter):
+    """
+    Deduplication filter which allows configuring a custom prefix in
+    the meta property ``fingerprint_prefix`` to be include in the request
+    fingerprint.
+
+    Useful to have different deduplication sets based on spider logic.
+    """
+
+    def request_fingerprint(self, request):
+        slot = request.meta.get('fingerprint_prefix', '')
+        fingerprint = request_fingerprint(request)
+        return f'{slot}{fingerprint}'
+

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -42,6 +42,11 @@ BACKEND = 'hcf_backend.HCFBackend'
 # Better concurrency with multiple domains
 SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'
 
+# Breadth-first order
+DEPTH_PRIORITY = 1
+SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'
+SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.FifoMemoryQueue'
+
 SPIDER_MIDDLEWARES = {
     'scrapy_link_filter.middleware.LinkFilterMiddleware': 950,
     'autoextract_spiders.middlewares.SchedulerSpiderMiddleware': 0,

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -8,6 +8,7 @@
 #     http://doc.scrapy.org/en/latest/topics/settings.html
 #     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 #     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
+import autoextract_spiders
 
 BOT_NAME = 'autoextract_spiders'
 
@@ -39,6 +40,9 @@ RETRY_HTTP_CODES = [429]
 SCHEDULER = 'scrapy_frontera.scheduler.FronteraScheduler'
 BACKEND = 'hcf_backend.HCFBackend'
 
+# Better concurrency with multiple domains
+SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'
+
 SPIDER_MIDDLEWARES = {
     'scrapy_link_filter.middleware.LinkFilterMiddleware': 950,
     'autoextract_spiders.middlewares.SchedulerSpiderMiddleware': 0,
@@ -53,6 +57,9 @@ DOWNLOADER_MIDDLEWARES = {
     'scrapy_count_filter.middleware.HostsCountFilterMiddleware': 542,
     'scrapy_autoextract.middlewares.AutoExtractMiddleware': 543,
 }
+
+# Custom filter to allow fingerprinting prefix customization
+DUPEFILTER_CLASS = 'autoextract_spiders.dupe_filter.DupeFilter'
 
 AUTOEXTRACT_USER = '[API key]'
 

--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -8,7 +8,6 @@
 #     http://doc.scrapy.org/en/latest/topics/settings.html
 #     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 #     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
-import autoextract_spiders
 
 BOT_NAME = 'autoextract_spiders'
 

--- a/autoextract_spiders/spiders/autoextract_article.py
+++ b/autoextract_spiders/spiders/autoextract_article.py
@@ -130,14 +130,11 @@ class ArticleAutoExtract(CrawlerSpider):
 
         for url in seen:
             self.crawler.stats.inc_value('links/rss')
-            # Make a request to fetch the full page HTML
-            # Risk of being banned
-            self.crawler.stats.inc_value('x_request/discovery')
-            yield Request(url,
-                          meta={'source_url': source_url, 'feed_url': feed_url},
-                          callback=self.parse_page,
-                          errback=self.errback_page,
-                          dont_filter=self.dont_filter)
+            yield self.make_extract_request(url,
+                                            meta={'source_url': source_url,
+                                                  'feed_url': feed_url,
+                                                  'dont_filter': self.dont_filter},
+                                            check_page_type=False)
 
     def errback_feed(self, failure):
         """ Feed XML request error """

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -204,6 +204,8 @@ class AutoExtractSpider(Spider):
             # Add source URL
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
+            if response.meta.get("referrer_url"):
+                item['referrer_url'] = response.meta['referrer_url']
             # Add current timestamp
             item['scraped_at'] = utc_iso_date()
             yield item

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -7,7 +7,8 @@ from scrapy.exceptions import IgnoreRequest, DropItem
 import scrapy_autoextract.middlewares
 
 from ..__version__ import __version__
-from .util import load_sources, is_valid_url, is_blacklisted_url
+from .util import load_sources, is_valid_url, is_blacklisted_url, \
+    FingerprintPrefix
 from .util import utc_iso_date, maybe_is_article, maybe_is_product, maybe_is_job_posting
 
 DEFAULT_THRESHOLD = .1
@@ -162,12 +163,12 @@ class AutoExtractSpider(Spider):
             return
         meta = meta or {}
         meta['cf_store'] = True
+        meta['fingerprint_prefix'] = FingerprintPrefix.AUTOEXTRACT.value
         req = AutoExtractRequest(url,
                                  meta=meta,
                                  page_type=self.page_type,
                                  callback=self.parse_item,
-                                 errback=self.errback_item,
-                                 dont_filter=True)
+                                 errback=self.errback_item)
 
         if check_page_type:
             if (self.page_type == 'article' and not maybe_is_article(url)) or \

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -114,7 +114,9 @@ class AutoExtractSpider(Spider):
         one_url = getattr(self, 'url', '')
         if one_url:
             self.logger.info('Using one item URL: %s', one_url)
-            autoextract_req = self.make_extract_request(one_url, check_page_type=False)
+            autoextract_req = self.make_extract_request(one_url,
+                                                        meta={'dont_filter': True},
+                                                        check_page_type=False)
             if autoextract_req:
                 yield autoextract_req
             return
@@ -145,7 +147,9 @@ class AutoExtractSpider(Spider):
             except Exception as err:
                 self.logger.warning('Invalid sources file: %s %s', items, err)
             for link in links:
-                autoextract_req = self.make_extract_request(link, check_page_type=False)
+                autoextract_req = self.make_extract_request(link,
+                                                            meta={'dont_filter': True},
+                                                            check_page_type=False)
                 if autoextract_req:
                     yield autoextract_req
 

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -204,8 +204,6 @@ class AutoExtractSpider(Spider):
             # Add source URL
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
-            if response.meta.get("referrer_url"):
-                item['referrer_url'] = response.meta['referrer_url']
             # Add current timestamp
             item['scraped_at'] = utc_iso_date()
             yield item

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -224,7 +224,7 @@ class CrawlerSpider(AutoExtractSpider):
             # Initial request to the seed URL
             self.crawler.stats.inc_value('x_request/seeds')
             yield Request(url,
-                          meta={'source_url': url},
+                          meta={'source_url': url, 'referrer_url': url},
                           callback=self.main_callback,
                           errback=self.main_errback,
                           dont_filter=True)

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -224,7 +224,7 @@ class CrawlerSpider(AutoExtractSpider):
             # Initial request to the seed URL
             self.crawler.stats.inc_value('x_request/seeds')
             request = Request(url,
-                          meta={'source_url': url, 'referrer_url': url},
+                          meta={'source_url': url},
                           callback=self.main_callback,
                           errback=self.main_errback,
                           dont_filter=True)
@@ -251,8 +251,6 @@ class CrawlerSpider(AutoExtractSpider):
             # For discovery-only mode, return only the URLs
             item = {'url': response.url}
             item['scraped_at'] = utc_iso_date()
-            if response.meta.get("referrer_url"):
-                item['referrer_url'] = response.meta['referrer_url']
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
             if response.meta.get('link_text'):
@@ -270,7 +268,6 @@ class CrawlerSpider(AutoExtractSpider):
             # Risk of being banned
             self.crawler.stats.inc_value('x_request/discovery')
             meta = {'source_url': response.meta['source_url'],
-                    'referrer_url': response.meta.get('referrer_url', 'unknown'),
                     'fingerprint_prefix': FingerprintPrefix.SCRAPY.value}
             request = Request(response.url,
                           meta=meta,
@@ -312,7 +309,7 @@ class CrawlerSpider(AutoExtractSpider):
                 links = rule.process_links(links)
             for link in links:
                 seen.add(link.url)
-                meta = {'rule': n, 'link_text': link.text, 'referrer_url': response.url,}
+                meta = {'rule': n, 'link_text': link.text}
                 request = self.make_extract_request(link.url, meta=meta)
                 if not request:
                     continue

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -245,6 +245,8 @@ class CrawlerSpider(AutoExtractSpider):
             # For discovery-only mode, return only the URLs
             item = {'url': response.url}
             item['scraped_at'] = utc_iso_date()
+            if response.meta.get("referrer_url"):
+                item['referrer_url'] = response.meta['referrer_url']
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
             if response.meta.get('link_text'):
@@ -262,6 +264,7 @@ class CrawlerSpider(AutoExtractSpider):
             # Risk of being banned
             self.crawler.stats.inc_value('x_request/discovery')
             meta = {'source_url': response.meta['source_url'],
+                    'referrer_url': response.meta.get('referrer_url', 'unknown'),
                     'fingerprint_prefix': FingerprintPrefix.SCRAPY.value}
             request = Request(response.url,
                           meta=meta,
@@ -303,7 +306,7 @@ class CrawlerSpider(AutoExtractSpider):
                 links = rule.process_links(links)
             for link in links:
                 seen.add(link.url)
-                meta = {'rule': n, 'link_text': link.text}
+                meta = {'rule': n, 'link_text': link.text, 'referrer_url': response.url,}
                 request = self.make_extract_request(link.url, meta=meta)
                 if not request:
                     continue

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -223,11 +223,17 @@ class CrawlerSpider(AutoExtractSpider):
                 continue
             # Initial request to the seed URL
             self.crawler.stats.inc_value('x_request/seeds')
-            yield Request(url,
+            request = Request(url,
                           meta={'source_url': url, 'referrer_url': url},
                           callback=self.main_callback,
                           errback=self.main_errback,
                           dont_filter=True)
+            # Trick required to avoid some seeds to be never processed or too late.
+            try:
+                self.crawler.engine.crawl(request, self)
+            except AssertionError:
+                yield request
+
 
     def parse_page(self, response):
         """

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -10,7 +10,8 @@ from scrapy.utils.misc import arg_to_iter
 from ..sessions import crawlera_session, update_redirect_middleware
 from .rule import Rule
 from .autoextract_spider import AutoExtractSpider
-from .util import is_valid_url, utc_iso_date, is_autoextract_request
+from .util import is_valid_url, utc_iso_date, is_autoextract_request, \
+    FingerprintPrefix
 
 META_TO_KEEP = ('source_url',)
 
@@ -260,11 +261,12 @@ class CrawlerSpider(AutoExtractSpider):
             # Make another request to fetch the full page HTML
             # Risk of being banned
             self.crawler.stats.inc_value('x_request/discovery')
+            meta = {'source_url': response.meta['source_url'],
+                    'fingerprint_prefix': FingerprintPrefix.SCRAPY.value}
             request = Request(response.url,
-                          meta={'source_url': response.meta['source_url']},
+                          meta=meta,
                           callback=self.main_callback,
-                          errback=self.main_errback,
-                          dont_filter=True)
+                          errback=self.main_errback)
             yield crawlera_session.init_request(request)
 
     def _rule_process_links(self, links):

--- a/autoextract_spiders/spiders/util.py
+++ b/autoextract_spiders/spiders/util.py
@@ -1,6 +1,7 @@
 import os
 import re
 import logging
+from enum import Enum
 from typing import Iterable
 from urllib.parse import urlsplit
 from datetime import datetime, timezone
@@ -190,3 +191,12 @@ def _load_jl(data: str) -> Iterable:
                 yield {'url': line}
             else:
                 logger.warning('Invalid source URL: %s', line)
+
+
+class FingerprintPrefix(Enum):
+    """
+    Prefixes to use in fingerprinting given the type of request performed.
+    Allows to have independent deduplication for Scrapy and AutoExtract requests.
+    """
+    SCRAPY = 's'  # For Scrapy requests
+    AUTOEXTRACT = 'a'  # For AutoExtract requests


### PR DESCRIPTION
A new dedup filter was included which allows having different deduplication sets. This is handy to have independent deduplicaiton for  AutoExtract and Scrapy requests. This approach avoids deduplication cycles (e.g. a site with links to www.examplesite.com/contact that are redirected to www.examplesite.com/contact/)

Also scrapy.pqueues.DownloaderAwarePriorityQueue was enabled for better scheduling and concurrency

I removed `dont_filter=True`, from here:
https://github.com/scrapinghub/autoextract-spiders/blob/master/autoextract_spiders/spiders/crawler_spider.py#L267
and here:
https://github.com/scrapinghub/autoextract-spiders/blob/master/autoextract_spiders/spiders/autoextract_spider.py#L170 . I think is the right thing to do because instead, we have individual deduplication to AutoExtract and Scrapy requests. But I wonder if I'm missing something and `dont_filter=True` was required for some particular reason. Reviewers, what do you think? Is maybe related with Frontera somehow?

I also found other places with `dont_filter=True`, for example here where the feeds are loaded: https://github.com/scrapinghub/autoextract-spiders/blob/master/autoextract_spiders/spiders/autoextract_article.py#L64

I also think that they should be removed, but I'm unsure. Do you know why are they required?

