### PR TITLE
Breadth-first order for crawling

### DIFF
--- a/autoextract_spiders/settings.py
+++ b/autoextract_spiders/settings.py
@@ -42,6 +42,11 @@ BACKEND = 'hcf_backend.HCFBackend'
 # Better concurrency with multiple domains
 SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'
 
+# Breadth-first order
+DEPTH_PRIORITY = 1
+SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'
+SCHEDULER_MEMORY_QUEUE = 'scrapy.squeues.FifoMemoryQueue'
+
 SPIDER_MIDDLEWARES = {
     'scrapy_link_filter.middleware.LinkFilterMiddleware': 950,
     'autoextract_spiders.middlewares.SchedulerSpiderMiddleware': 0,

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -204,6 +204,8 @@ class AutoExtractSpider(Spider):
             # Add source URL
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
+            if response.meta.get("referrer_url"):
+                item['referrer_url'] = response.meta['referrer_url']
             # Add current timestamp
             item['scraped_at'] = utc_iso_date()
             yield item

--- a/autoextract_spiders/spiders/autoextract_spider.py
+++ b/autoextract_spiders/spiders/autoextract_spider.py
@@ -204,8 +204,6 @@ class AutoExtractSpider(Spider):
             # Add source URL
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
-            if response.meta.get("referrer_url"):
-                item['referrer_url'] = response.meta['referrer_url']
             # Add current timestamp
             item['scraped_at'] = utc_iso_date()
             yield item

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -224,7 +224,7 @@ class CrawlerSpider(AutoExtractSpider):
             # Initial request to the seed URL
             self.crawler.stats.inc_value('x_request/seeds')
             yield Request(url,
-                          meta={'source_url': url},
+                          meta={'source_url': url, 'referrer_url': url},
                           callback=self.main_callback,
                           errback=self.main_errback,
                           dont_filter=True)

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -224,7 +224,7 @@ class CrawlerSpider(AutoExtractSpider):
             # Initial request to the seed URL
             self.crawler.stats.inc_value('x_request/seeds')
             request = Request(url,
-                          meta={'source_url': url, 'referrer_url': url},
+                          meta={'source_url': url},
                           callback=self.main_callback,
                           errback=self.main_errback,
                           dont_filter=True)
@@ -251,8 +251,6 @@ class CrawlerSpider(AutoExtractSpider):
             # For discovery-only mode, return only the URLs
             item = {'url': response.url}
             item['scraped_at'] = utc_iso_date()
-            if response.meta.get("referrer_url"):
-                item['referrer_url'] = response.meta['referrer_url']
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
             if response.meta.get('link_text'):
@@ -270,7 +268,6 @@ class CrawlerSpider(AutoExtractSpider):
             # Risk of being banned
             self.crawler.stats.inc_value('x_request/discovery')
             meta = {'source_url': response.meta['source_url'],
-                    'referrer_url': response.meta.get('referrer_url', 'unknown'),
                     'fingerprint_prefix': FingerprintPrefix.SCRAPY.value}
             request = Request(response.url,
                           meta=meta,
@@ -312,7 +309,7 @@ class CrawlerSpider(AutoExtractSpider):
                 links = rule.process_links(links)
             for link in links:
                 seen.add(link.url)
-                meta = {'rule': n, 'link_text': link.text, 'referrer_url': response.url,}
+                meta = {'rule': n, 'link_text': link.text}
                 request = self.make_extract_request(link.url, meta=meta)
                 if not request:
                     continue

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -245,6 +245,8 @@ class CrawlerSpider(AutoExtractSpider):
             # For discovery-only mode, return only the URLs
             item = {'url': response.url}
             item['scraped_at'] = utc_iso_date()
+            if response.meta.get("referrer_url"):
+                item['referrer_url'] = response.meta['referrer_url']
             if response.meta.get('source_url'):
                 item['source_url'] = response.meta['source_url']
             if response.meta.get('link_text'):
@@ -262,6 +264,7 @@ class CrawlerSpider(AutoExtractSpider):
             # Risk of being banned
             self.crawler.stats.inc_value('x_request/discovery')
             meta = {'source_url': response.meta['source_url'],
+                    'referrer_url': response.meta.get('referrer_url', 'unknown'),
                     'fingerprint_prefix': FingerprintPrefix.SCRAPY.value}
             request = Request(response.url,
                           meta=meta,
@@ -303,7 +306,7 @@ class CrawlerSpider(AutoExtractSpider):
                 links = rule.process_links(links)
             for link in links:
                 seen.add(link.url)
-                meta = {'rule': n, 'link_text': link.text}
+                meta = {'rule': n, 'link_text': link.text, 'referrer_url': response.url,}
                 request = self.make_extract_request(link.url, meta=meta)
                 if not request:
                     continue

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -223,11 +223,17 @@ class CrawlerSpider(AutoExtractSpider):
                 continue
             # Initial request to the seed URL
             self.crawler.stats.inc_value('x_request/seeds')
-            yield Request(url,
+            request = Request(url,
                           meta={'source_url': url, 'referrer_url': url},
                           callback=self.main_callback,
                           errback=self.main_errback,
                           dont_filter=True)
+            # Trick required to avoid some seeds to be never processed or too late.
+            try:
+                self.crawler.engine.crawl(request, self)
+            except AssertionError:
+                yield request
+
 
     def parse_page(self, response):
         """


### PR DESCRIPTION
BF order for crawling is better suited IMO for autoextract-spiders

Also, I included a trick to force the crawling of the seeds. Otherwise, some of them can get ignored. 

This PR depends on https://github.com/scrapinghub/autoextract-spiders/pull/25 