### PR TITLE
Set/reset Frontera for all page types

### DIFF
--- a/autoextract_spiders/spiders/autoextract_article.py
+++ b/autoextract_spiders/spiders/autoextract_article.py
@@ -2,7 +2,6 @@ import feedparser
 from w3lib.html import strip_html5_whitespace
 from scrapy.http import Request, TextResponse, HtmlResponse
 
-from ..middlewares import reset_scheduler_on_disabled_frontera
 from ..sessions import crawlera_session
 from .util import is_valid_url
 from .crawler_spider import CrawlerSpider
@@ -11,22 +10,6 @@ from .crawler_spider import CrawlerSpider
 class ArticleAutoExtract(CrawlerSpider):
     name = 'articles'
     page_type = 'article'
-
-    frontera_settings = {
-        'HCF_PRODUCER_FRONTIER': 'autoextract',
-        'HCF_PRODUCER_SLOT_PREFIX': 'articles',
-        'HCF_PRODUCER_NUMBER_OF_SLOTS': 1,
-        'HCF_PRODUCER_BATCH_SIZE': 100,
-
-        'HCF_CONSUMER_FRONTIER': 'autoextract',
-        'HCF_CONSUMER_SLOT': 'articles0',
-        'HCF_CONSUMER_MAX_REQUESTS': 100,
-    }
-
-    @classmethod
-    def update_settings(cls, settings):
-        super().update_settings(settings)
-        reset_scheduler_on_disabled_frontera(settings)
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -7,6 +7,7 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.exceptions import IgnoreRequest, DropItem
 from scrapy.utils.misc import arg_to_iter
 
+from ..middlewares import reset_scheduler_on_disabled_frontera
 from ..sessions import crawlera_session, update_redirect_middleware
 from .rule import Rule
 from .autoextract_spider import AutoExtractSpider
@@ -66,9 +67,21 @@ class CrawlerSpider(AutoExtractSpider):
              follow=True),
     ]
 
+    frontera_settings = {
+        'HCF_PRODUCER_FRONTIER': 'autoextract',
+        'HCF_PRODUCER_SLOT_PREFIX': 'items',
+        'HCF_PRODUCER_NUMBER_OF_SLOTS': 1,
+        'HCF_PRODUCER_BATCH_SIZE': 100,
+
+        'HCF_CONSUMER_FRONTIER': 'autoextract',
+        'HCF_CONSUMER_SLOT': 'items0',
+        'HCF_CONSUMER_MAX_REQUESTS': 100,
+    }
+
     @classmethod
     def update_settings(cls, settings):
         super().update_settings(settings)
+        reset_scheduler_on_disabled_frontera(settings)
         update_redirect_middleware(settings)
 
     @classmethod

--- a/autoextract_spiders/spiders/crawler_spider.py
+++ b/autoextract_spiders/spiders/crawler_spider.py
@@ -69,12 +69,12 @@ class CrawlerSpider(AutoExtractSpider):
 
     frontera_settings = {
         'HCF_PRODUCER_FRONTIER': 'autoextract',
-        'HCF_PRODUCER_SLOT_PREFIX': 'items',
+        'HCF_PRODUCER_SLOT_PREFIX': 'queue',
         'HCF_PRODUCER_NUMBER_OF_SLOTS': 1,
         'HCF_PRODUCER_BATCH_SIZE': 100,
 
         'HCF_CONSUMER_FRONTIER': 'autoextract',
-        'HCF_CONSUMER_SLOT': 'items0',
+        'HCF_CONSUMER_SLOT': 'queue0',
         'HCF_CONSUMER_MAX_REQUESTS': 100,
     }
 


### PR DESCRIPTION
I've just noticed that I added Frontera support but configured it only for articles spider, so it works incorrectly for other types now (Frontera is activated but doing nothing as not configured properly). It should be implemented in a uniform way for all child spiders we have here. 

The change isn't backward compatible as it uses a different slot naming (uniform one) but I wonder if it's a big deal.